### PR TITLE
feat: allow to chain handle, subscribe, onError and onAnyError

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deno.enable": true,
+  "editor.defaultFormatter": "denoland.vscode-deno",
   "eslint.enable": false,
   "prettier.enable": false,
   "biome.enable": false,

--- a/src/pathways/postgres/postgres-pathway-state.ts
+++ b/src/pathways/postgres/postgres-pathway-state.ts
@@ -1,26 +1,26 @@
-import type { PathwayState } from "../types.ts";
-import type { PostgresAdapter } from "./postgres-adapter.ts";
-import { createPostgresAdapter } from "./postgres-adapter.ts";
+import type { PathwayState } from "../types.ts"
+import type { PostgresAdapter } from "./postgres-adapter.ts"
+import { createPostgresAdapter } from "./postgres-adapter.ts"
 
 /**
  * Configuration for PostgreSQL pathway state storage using a connection string
  */
 export interface PostgresPathwayStateConnectionStringConfig {
   /** Complete PostgreSQL connection string (e.g., postgres://user:password@host:port/database?sslmode=require) */
-  connectionString: string;
+  connectionString: string
 
   /** These properties are not used when a connection string is provided */
-  host?: never;
-  port?: never;
-  user?: never;
-  password?: never;
-  database?: never;
-  ssl?: never;
+  host?: never
+  port?: never
+  user?: never
+  password?: never
+  database?: never
+  ssl?: never
 
   /** Table name for storing pathway state (default: "pathway_state") */
-  tableName?: string;
+  tableName?: string
   /** Time-to-live in milliseconds for processed events (default: 5 minutes) */
-  ttlMs?: number;
+  ttlMs?: number
 }
 
 /**
@@ -28,25 +28,25 @@ export interface PostgresPathwayStateConnectionStringConfig {
  */
 export interface PostgresPathwayStateParametersConfig {
   /** Not used when individual parameters are provided */
-  connectionString?: never;
+  connectionString?: never
 
   /** PostgreSQL server hostname */
-  host: string;
+  host: string
   /** PostgreSQL server port */
-  port: number;
+  port: number
   /** PostgreSQL username */
-  user: string;
+  user: string
   /** PostgreSQL password */
-  password: string;
+  password: string
   /** PostgreSQL database name */
-  database: string;
+  database: string
   /** Whether to use SSL for the connection */
-  ssl?: boolean;
+  ssl?: boolean
 
   /** Table name for storing pathway state (default: "pathway_state") */
-  tableName?: string;
+  tableName?: string
   /** Time-to-live in milliseconds for processed events (default: 5 minutes) */
-  ttlMs?: number;
+  ttlMs?: number
 }
 
 /**
@@ -56,7 +56,9 @@ export interface PostgresPathwayStateParametersConfig {
  * 1. A complete connection string, or
  * 2. Individual connection parameters (host, port, user, etc.)
  */
-export type PostgresPathwayStateConfig = PostgresPathwayStateConnectionStringConfig | PostgresPathwayStateParametersConfig;
+export type PostgresPathwayStateConfig =
+  | PostgresPathwayStateConnectionStringConfig
+  | PostgresPathwayStateParametersConfig
 
 /**
  * Implementation of PathwayState that uses PostgreSQL for storage
@@ -110,37 +112,37 @@ export class PostgresPathwayState implements PathwayState {
    * Default time-to-live for processed event records (5 minutes)
    * @private
    */
-  private static readonly DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+  private static readonly DEFAULT_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
   /**
    * Default table name for storing pathway state
    * @private
    */
-  private static readonly DEFAULT_TABLE_NAME = "pathway_state";
+  private static readonly DEFAULT_TABLE_NAME = "pathway_state"
 
   /**
    * The PostgreSQL adapter instance
    * @private
    */
-  private postgres: PostgresAdapter;
+  private postgres: PostgresAdapter
 
   /**
    * The table name for storing pathway state
    * @private
    */
-  private tableName: string;
+  private tableName: string
 
   /**
    * Time-to-live in milliseconds for processed events
    * @private
    */
-  private ttlMs: number;
+  private ttlMs: number
 
   /**
    * Whether the database has been initialized
    * @private
    */
-  private initialized = false;
+  private initialized = false
 
   /**
    * Creates a new PostgresPathwayState instance
@@ -148,9 +150,9 @@ export class PostgresPathwayState implements PathwayState {
    * @param {PostgresPathwayStateConfig} config The PostgreSQL configuration
    */
   constructor(private config: PostgresPathwayStateConfig) {
-    this.tableName = config.tableName || PostgresPathwayState.DEFAULT_TABLE_NAME;
-    this.ttlMs = config.ttlMs || PostgresPathwayState.DEFAULT_TTL_MS;
-    this.postgres = null as unknown as PostgresAdapter;
+    this.tableName = config.tableName || PostgresPathwayState.DEFAULT_TABLE_NAME
+    this.ttlMs = config.ttlMs || PostgresPathwayState.DEFAULT_TTL_MS
+    this.postgres = null as unknown as PostgresAdapter
   }
 
   /**
@@ -161,15 +163,15 @@ export class PostgresPathwayState implements PathwayState {
    */
   private async initialize(): Promise<void> {
     if (this.initialized) {
-      return;
+      return
     }
 
     // Create adapter using either connection string or individual parameters
-    if ('connectionString' in this.config && this.config.connectionString) {
+    if ("connectionString" in this.config && this.config.connectionString) {
       // Use connection string if provided
       this.postgres = await createPostgresAdapter({
-        connectionString: this.config.connectionString
-      });
+        connectionString: this.config.connectionString,
+      })
     } else {
       // We know this must be the parameters config due to the type union
       // TypeScript just needs help with narrowing the type
@@ -180,17 +182,20 @@ export class PostgresPathwayState implements PathwayState {
         password: this.config.password as string,
         database: this.config.database as string,
         ssl: this.config.ssl,
-      });
+      })
     }
 
     // Check if the table exists
-    const tableExists = await this.postgres.query<{ exists: boolean }[]>(`
+    const tableExists = await this.postgres.query<{ exists: boolean }[]>(
+      `
       SELECT EXISTS (
         SELECT 1
         FROM information_schema.tables
         WHERE table_name = $1
       )
-    `, [this.tableName]);
+    `,
+      [this.tableName],
+    )
     if (!tableExists[0]?.exists) {
       // Create table if it doesn't exist
       await this.postgres.execute(`
@@ -200,15 +205,15 @@ export class PostgresPathwayState implements PathwayState {
           created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
           expires_at TIMESTAMP WITH TIME ZONE NOT NULL
         )
-      `);
+      `)
 
       // Create index on expires_at to help with cleanup
       await this.postgres.execute(`
         CREATE INDEX IF NOT EXISTS ${this.tableName}_expires_at_idx ON ${this.tableName} (expires_at)
-      `);
+      `)
     }
 
-    this.initialized = true;
+    this.initialized = true
   }
 
   /**
@@ -240,17 +245,20 @@ export class PostgresPathwayState implements PathwayState {
    * ```
    */
   async isProcessed(eventId: string): Promise<boolean> {
-    await this.initialize();
+    await this.initialize()
 
     // Clean up expired entries
-    await this.cleanupExpired();
+    await this.cleanupExpired()
 
-    const result = await this.postgres.query<{ processed: boolean }[]>(`
+    const result = await this.postgres.query<{ processed: boolean }[]>(
+      `
       SELECT processed FROM ${this.tableName}
       WHERE event_id = $1 AND expires_at > NOW()
-    `, [eventId]);
+    `,
+      [eventId],
+    )
 
-    return result.length > 0 && result[0].processed;
+    return result.length > 0 && result[0].processed
   }
 
   /**
@@ -289,18 +297,21 @@ export class PostgresPathwayState implements PathwayState {
    * ```
    */
   async setProcessed(eventId: string): Promise<void> {
-    await this.initialize();
+    await this.initialize()
 
     // Insert or update the event state
     // Using ON CONFLICT to handle the case where the event is already in the table
-    await this.postgres.execute(`
+    await this.postgres.execute(
+      `
       INSERT INTO ${this.tableName} (event_id, processed, expires_at)
       VALUES ($1, TRUE, NOW() + interval '${Math.floor(this.ttlMs / 1000)} seconds')
       ON CONFLICT (event_id)
       DO UPDATE SET
         processed = TRUE,
         expires_at = NOW() + interval '${Math.floor(this.ttlMs / 1000)} seconds'
-    `, [eventId]);
+    `,
+      [eventId],
+    )
   }
 
   /**
@@ -314,7 +325,7 @@ export class PostgresPathwayState implements PathwayState {
     await this.postgres.execute(`
       DELETE FROM ${this.tableName}
       WHERE expires_at < NOW()
-    `);
+    `)
   }
 
   /**
@@ -324,7 +335,7 @@ export class PostgresPathwayState implements PathwayState {
    */
   async close(): Promise<void> {
     if (this.postgres) {
-      await this.postgres.disconnect();
+      await this.postgres.disconnect()
     }
   }
 }
@@ -374,6 +385,6 @@ export class PostgresPathwayState implements PathwayState {
  * ```
  */
 export function createPostgresPathwayState(config: PostgresPathwayStateConfig): PostgresPathwayState {
-  const state = new PostgresPathwayState(config);
-  return state;
+  const state = new PostgresPathwayState(config)
+  return state
 }


### PR DESCRIPTION
Allow chaining of handlers, subscribe, onError and onAnyError

```ts
export const pathways = new PathwaysBuilder({
  baseUrl: env.FLOWCORE_WEBHOOK_BASEURL,
  tenant: env.FLOWCORE_TENANT,
  dataCore: env.FLOWCORE_DATACORE,
  apiKey: env.FLOWCORE_WEBHOOK_API_KEY,
  logger,
})
.register({
    flowType: dataContract.flowType,
    eventType: dataContract.eventTypes.created,
    schema: dataContract.EventDataCreatedSchema,
    writable: true,
  })
.handle("data.0/data.created.0", dataContract.handlerDataCreated)
.register({ ... })
.onError(...)
.onAnyError(...)
```