### PR TITLE
feat!: poll-based command queue for virtual pathway resets

### DIFF
--- a/src/pathways/builder.ts
+++ b/src/pathways/builder.ts
@@ -7,6 +7,7 @@ import type { FlowcoreEvent } from "../contracts/event.ts"
 import { InternalPathwayState } from "./internal-pathway.state.ts"
 import type { Logger } from "./logger.ts"
 import { NoopLogger } from "./logger.ts"
+import { CommandPoller } from "./command-poller.ts"
 import type {
   EventMetadata,
   PathwayContract,
@@ -298,16 +299,15 @@ export class PathwaysBuilder<
   // Virtual pathway auto-provisioning
   private readonly pathwayName?: string
   private readonly pathwayLabels: Record<string, string>
-  private readonly advertisedUrl?: string
-  private readonly resetSecret?: string
-  private readonly resetPath: string
   private readonly pulseUrl: string
   private readonly pulseIntervalMs: number
+  private readonly commandPollingIntervalMs: number
   private pathwayId?: string
 
-  // Cluster + pump
+  // Cluster + pump + command poller
   private clusterManager: ClusterManager | null = null
   private pathwayPump: PathwayPump | null = null
+  private commandPoller: CommandPoller | null = null
   private clusterBypassProcess = false
 
   /**
@@ -339,11 +339,12 @@ export class PathwaysBuilder<
     dataCoreDeleteProtection,
     pathwayName,
     pathwayLabels,
-    advertisedUrl,
-    resetSecret,
-    resetPath,
+    advertisedUrl: _advertisedUrl,
+    resetSecret: _resetSecret,
+    resetPath: _resetPath,
     pulseUrl,
     pulseIntervalMs,
+    commandPollingIntervalMs,
   }: {
     baseUrl: string
     tenant: string
@@ -359,11 +360,15 @@ export class PathwaysBuilder<
     dataCoreDeleteProtection?: boolean
     pathwayName?: string
     pathwayLabels?: Record<string, string>
+    /** @deprecated No longer used — virtual pathway commands are now poll-based */
     advertisedUrl?: string
+    /** @deprecated No longer used — virtual pathway commands are now poll-based */
     resetSecret?: string
+    /** @deprecated No longer used — virtual pathway commands are now poll-based */
     resetPath?: string
     pulseUrl?: string
     pulseIntervalMs?: number
+    commandPollingIntervalMs?: number
   }) {
     // Initialize logger (use NoopLogger if none provided)
     this.logger = logger ?? new NoopLogger()
@@ -389,21 +394,11 @@ export class PathwaysBuilder<
     this.dataCoreDeleteProtection = dataCoreDeleteProtection ?? false
 
     // Store virtual pathway auto-provisioning config
-    if (pathwayName) {
-      if (!advertisedUrl) {
-        throw new Error("advertisedUrl is required when pathwayName is set")
-      }
-      if (!resetSecret) {
-        throw new Error("resetSecret is required when pathwayName is set")
-      }
-    }
     this.pathwayName = pathwayName
     this.pathwayLabels = pathwayLabels ?? {}
-    this.advertisedUrl = advertisedUrl
-    this.resetSecret = resetSecret
-    this.resetPath = resetPath ?? "/reset"
     this.pulseUrl = pulseUrl ?? "https://data-pathways.api.flowcore.io"
     this.pulseIntervalMs = pulseIntervalMs ?? 30_000
+    this.commandPollingIntervalMs = commandPollingIntervalMs ?? 5_000
 
     if (enableSessionUserResolvers) {
       this.sessionUserResolvers = overrideSessionUserResolvers ?? new SessionUser()
@@ -1316,8 +1311,6 @@ export class PathwaysBuilder<
             dataCore: this.dataCore,
             labels: this.pathwayLabels,
             virtualConfig: {
-              resetUrl: `${this.advertisedUrl}${this.resetPath}`,
-              authHeaders: { "x-pump-reset-secret": this.resetSecret },
               flowTypes,
             },
           }),
@@ -1438,6 +1431,34 @@ export class PathwaysBuilder<
       pathways: registrations.length,
     })
 
+    // Auto-start command poller for virtual pathways (poll CP for restart commands)
+    if (this.pathwayId && !this.commandPoller) {
+      this.commandPoller = new CommandPoller({
+        cpBaseUrl: this.pulseUrl,
+        pathwayId: this.pathwayId,
+        apiKey: this.apiKey,
+        intervalMs: this.commandPollingIntervalMs,
+        logger: this.logger,
+        onCommand: async (cmd) => {
+          if (cmd.type === "datapumpRestart") {
+            const position = cmd.position
+              ? { timeBucket: (cmd.position as Record<string, string>).timeBucket ?? "", eventId: (cmd.position as Record<string, string>).eventId }
+              : undefined
+            const flowTypes = cmd.sourceFlowTypes ?? undefined
+            await this.pathwayPump!.reset(position, flowTypes)
+          } else {
+            this.logger.warn("Unknown command type received", { type: cmd.type, commandId: cmd.id })
+          }
+        },
+        logLevel: {
+          pollSuccess: this.logLevel.pulseSuccess,
+          pollFailure: this.logLevel.pulseFailure,
+        },
+      })
+      this.commandPoller.start()
+      this.logger.info("Command poller started", { pathwayId: this.pathwayId, intervalMs: this.commandPollingIntervalMs })
+    }
+
     return this.pathwayPump
   }
 
@@ -1445,6 +1466,10 @@ export class PathwaysBuilder<
    * Stop the data pump
    */
   async stopPump(): Promise<void> {
+    if (this.commandPoller) {
+      this.commandPoller.stop()
+      this.commandPoller = null
+    }
     if (!this.pathwayPump) return
     await this.pathwayPump.stop()
     this.pathwayPump = null

--- a/src/pathways/command-poller.ts
+++ b/src/pathways/command-poller.ts
@@ -1,0 +1,180 @@
+import type { Logger } from "./logger.ts"
+import type { LogLevel } from "./builder.ts"
+
+export interface PendingCommand {
+  id: string
+  type: string
+  position: Record<string, unknown> | null
+  sourceFlowTypes: string[] | null
+  reason: string | null
+  stopAt: string | null
+}
+
+interface PendingCommandsResponse {
+  commands: PendingCommand[]
+}
+
+export interface CommandPollerOptions {
+  cpBaseUrl: string
+  pathwayId: string
+  apiKey: string
+  intervalMs: number
+  logger: Logger
+  onCommand: (command: PendingCommand) => Promise<void>
+  logLevel: {
+    pollSuccess: LogLevel
+    pollFailure: LogLevel
+  }
+}
+
+function formatAuthHeader(apiKey: string): string {
+  return `ApiKey ${apiKey.startsWith("fc_") ? `${apiKey.split("_")[1]}:${apiKey}` : apiKey}`
+}
+
+export class CommandPoller {
+  private readonly cpBaseUrl: string
+  private readonly pathwayId: string
+  private readonly apiKey: string
+  private readonly intervalMs: number
+  private readonly logger: Logger
+  private readonly onCommand: (command: PendingCommand) => Promise<void>
+  private readonly logLevel: { pollSuccess: LogLevel; pollFailure: LogLevel }
+  private timer: ReturnType<typeof setInterval> | null = null
+  private polling = false
+
+  constructor(options: CommandPollerOptions) {
+    this.cpBaseUrl = options.cpBaseUrl
+    this.pathwayId = options.pathwayId
+    this.apiKey = options.apiKey
+    this.intervalMs = options.intervalMs
+    this.logger = options.logger
+    this.onCommand = options.onCommand
+    this.logLevel = options.logLevel
+  }
+
+  start(): void {
+    if (this.timer) return
+
+    this.logger.debug("Command poller starting", {
+      pathwayId: this.pathwayId,
+      intervalMs: this.intervalMs,
+    })
+
+    // Poll immediately on start, then on interval
+    this.poll()
+    this.timer = setInterval(() => this.poll(), this.intervalMs)
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    this.logger.debug("Command poller stopped", { pathwayId: this.pathwayId })
+  }
+
+  private async poll(): Promise<void> {
+    // Guard against overlapping polls
+    if (this.polling) return
+    this.polling = true
+
+    try {
+      const url = `${this.cpBaseUrl}/api/v1/pathways/${this.pathwayId}/commands/pending`
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: formatAuthHeader(this.apiKey),
+        },
+      })
+
+      if (!response.ok) {
+        this.logger[this.logLevel.pollFailure]("Command poll failed", {
+          pathwayId: this.pathwayId,
+          status: response.status,
+        })
+        return
+      }
+
+      const body = (await response.json()) as PendingCommandsResponse
+
+      if (body.commands.length === 0) {
+        this.logger[this.logLevel.pollSuccess]("Command poll: no pending commands", {
+          pathwayId: this.pathwayId,
+        })
+        return
+      }
+
+      this.logger.info("Command poll: received commands", {
+        pathwayId: this.pathwayId,
+        count: body.commands.length,
+      })
+
+      for (const command of body.commands) {
+        await this.handleCommand(command)
+      }
+    } catch (err) {
+      this.logger[this.logLevel.pollFailure]("Command poll error", {
+        pathwayId: this.pathwayId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    } finally {
+      this.polling = false
+    }
+  }
+
+  private async handleCommand(command: PendingCommand): Promise<void> {
+    const statusUrl = `${this.cpBaseUrl}/api/v1/pathways/${this.pathwayId}/commands/${command.id}/status`
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: formatAuthHeader(this.apiKey),
+    }
+
+    // Acknowledge receipt
+    try {
+      await fetch(statusUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ phase: "acknowledged" }),
+      })
+    } catch {
+      // Best-effort ack — continue with execution
+    }
+
+    // Execute command
+    try {
+      await this.onCommand(command)
+
+      // Report success
+      await fetch(statusUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ phase: "running" }),
+      })
+
+      this.logger.info("Command executed successfully", {
+        commandId: command.id,
+        type: command.type,
+        pathwayId: this.pathwayId,
+      })
+    } catch (err) {
+      const details = err instanceof Error ? err.message : String(err)
+
+      // Report failure
+      try {
+        await fetch(statusUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ phase: "failed", details }),
+        })
+      } catch {
+        // Best-effort status report
+      }
+
+      this.logger.error("Command execution failed", err instanceof Error ? err : new Error(details), {
+        commandId: command.id,
+        type: command.type,
+        pathwayId: this.pathwayId,
+      })
+    }
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -191,10 +191,10 @@ export class PathwayRouter {
    * are now polled from the CP via GET /api/v1/pathways/:id/commands/pending.
    * The PathwaysBuilder auto-starts a CommandPoller when pathwayName is configured.
    */
-  async processReset(
+  processReset(
     _body: ResetCallbackBody,
     _providedSecret: string | null,
-  ): Promise<{ success: boolean; flowTypesReset: string[] }> {
+  ): { success: boolean; flowTypesReset: string[] } {
     this.logger.warn("processReset is deprecated — virtual pathway commands are now poll-based. This method is a no-op.")
     return { success: false, flowTypesReset: [] }
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -187,44 +187,21 @@ export class PathwayRouter {
   }
 
   /**
-   * Process an incoming virtual reset callback from the Data Pathways CP.
-   * Validates the secret, resolves which pumps to reset, and calls resetPump().
-   *
-   * @param body The reset callback body from the CP
-   * @param providedSecret The secret from the x-pump-reset-secret header
-   * @returns Result with success status and list of flow types that were reset
+   * @deprecated Use the poll-based command queue instead. Virtual pathway commands
+   * are now polled from the CP via GET /api/v1/pathways/:id/commands/pending.
+   * The PathwaysBuilder auto-starts a CommandPoller when pathwayName is configured.
    */
   async processReset(
-    body: ResetCallbackBody,
-    providedSecret: string | null,
+    _body: ResetCallbackBody,
+    _providedSecret: string | null,
   ): Promise<{ success: boolean; flowTypesReset: string[] }> {
-    // Validate secret key (same pattern as processEvent)
-    if (!providedSecret || providedSecret !== this.secretKey) {
-      const errorMsg = "Invalid secret key"
-      this.logger.error(errorMsg, new Error(errorMsg))
-      throw new Error(errorMsg)
-    }
-
-    this.logger.debug("Processing reset request", {
-      pathwayId: body.pathwayId,
-      mode: body.mode,
-      flowTypes: body.flowTypes,
-    })
-
-    const position = body.position
-      ? { timeBucket: body.position.timeBucket ?? "", eventId: body.position.eventId }
-      : undefined
-
-    const flowTypesReset = await this.pathways.resetPump(position, body.flowTypes)
-
-    this.logger.info("Reset completed", { flowTypesReset })
-
-    return { success: true, flowTypesReset }
+    this.logger.warn("processReset is deprecated — virtual pathway commands are now poll-based. This method is a no-op.")
+    return { success: false, flowTypesReset: [] }
   }
 }
 
 /**
- * Body shape for virtual reset callbacks from the Data Pathways CP.
+ * @deprecated No longer used — virtual pathway commands are now poll-based.
  */
 export interface ResetCallbackBody {
   pathwayId: string

--- a/tests/pathway-builder-config.test.ts
+++ b/tests/pathway-builder-config.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "https://deno.land/std@0.224.0/assert/mod.ts"
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts"
 import { PathwaysBuilder } from "../src/pathways/builder.ts"
 
 const baseOpts = {
@@ -17,40 +17,33 @@ Deno.test({
       const builder = new PathwaysBuilder({
         ...baseOpts,
         pathwayName: "my-service",
-        advertisedUrl: "https://my-service.example.com",
-        resetSecret: "my-reset-secret",
-        resetPath: "/admin/reset",
-        pulseUrl: "https://custom-cp.example.com/api/v1/pump-pulse",
+        pulseUrl: "https://custom-cp.example.com",
         pulseIntervalMs: 15000,
+        commandPollingIntervalMs: 3000,
       })
 
       assertEquals(typeof builder, "object")
     })
 
-    await t.step("should throw when pathwayName set but advertisedUrl missing", () => {
-      assertThrows(
-        () =>
-          new PathwaysBuilder({
-            ...baseOpts,
-            pathwayName: "my-service",
-            resetSecret: "my-reset-secret",
-          }),
-        Error,
-        "advertisedUrl is required when pathwayName is set",
-      )
+    await t.step("should accept deprecated fields without error (backward compat)", () => {
+      const builder = new PathwaysBuilder({
+        ...baseOpts,
+        pathwayName: "my-service",
+        advertisedUrl: "https://my-service.example.com",
+        resetSecret: "my-reset-secret",
+        resetPath: "/admin/reset",
+      })
+
+      assertEquals(typeof builder, "object")
     })
 
-    await t.step("should throw when pathwayName set but resetSecret missing", () => {
-      assertThrows(
-        () =>
-          new PathwaysBuilder({
-            ...baseOpts,
-            pathwayName: "my-service",
-            advertisedUrl: "https://my-service.example.com",
-          }),
-        Error,
-        "resetSecret is required when pathwayName is set",
-      )
+    await t.step("should accept pathwayName without advertisedUrl or resetSecret", () => {
+      const builder = new PathwaysBuilder({
+        ...baseOpts,
+        pathwayName: "my-service",
+      })
+
+      assertEquals(typeof builder, "object")
     })
 
     await t.step("should work without pathwayName (backward compat)", () => {


### PR DESCRIPTION
## Summary

- Replace push-based HTTP callback reset with pull-based command polling for virtual pathways
- New `CommandPoller` class polls `GET /api/v1/pathways/:pathwayId/commands/pending` every 5s
- Auto-starts when `pathwayName` is configured and pump starts — zero config for consumers
- On `datapumpRestart` command: acknowledges, calls `resetPump(position, flowTypes)`, reports `running`
- `advertisedUrl`, `resetSecret`, `resetPath` params deprecated (accepted but ignored for backwards compat)
- `processReset()` on `PathwayRouter` deprecated (no-op with warning)

Companion to flowcore-io/data-pathways#65 which added the CP-side polling endpoints.

## Test plan

- [ ] `deno check src/mod.ts` passes
- [ ] Existing consumers using `pathwayName` still compile (deprecated params accepted)
- [ ] Manual: configure PathwaysBuilder with `pathwayName`, start pump with `autoProvision: true`, issue restart via CP, observe poll → reset → status report

🤖 Generated with [Claude Code](https://claude.com/claude-code)