### PR TITLE
fix(pump): forward pulse pathwayId unmodified — strip ::flowType::pumpGroup suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,10 @@ What this gives you per pump group:
 - **Independent restart backoff.** A failure in the `hot` pump does not reset the cold pump's attempt counter, and the
   restart loop keeps retrying with exponential backoff (capped at 30s) until the pump comes back — including when the
   restart attempt itself throws synchronously.
-- **Per-group pulse identity.** When pulse reporting is configured, each pump emits pulses under
-  `${pathwayId}::${flowType}::${pumpGroup}` so the control plane can distinguish the health of each group.
+- **Pulse health.** When pulse reporting is configured, every group emits pulses with the resolved pathway UUID. The
+  Data Pathways CP pulse route (`POST /api/v1/pump-pulse`) validates `pathwayId` as a strict UUID, so each pulse goes
+  through unchanged regardless of pump group. Per-group health visibility (distinguishing `hot` from `default` for the
+  same flowType in the CP) is not yet wired and will land as an additive `pumpGroup` field through the SDK + CP.
 
 **Caveats (v2.4):**
 

--- a/src/pathways/pump/pathway-pump.ts
+++ b/src/pathways/pump/pathway-pump.ts
@@ -279,11 +279,17 @@ export class PathwayPump {
     }
 
     if (this.pulseConfig) {
-      const baseId = this.pulseConfig.pathwayId ?? "unknown"
+      // Send the resolved pathway UUID unmodified — the Data Pathways CP pulse
+      // route validates `pathwayId: z.string().uuid()` and rejects anything else
+      // with 400 BAD_REQUEST. Earlier versions of this file appended
+      // `::${flowType}::${pumpGroup}` to distinguish per-group health, but the
+      // CP was never updated to parse that suffix, so every 2.4.0 pulse was
+      // 400'd in production. Per-group health visibility will return as a
+      // proper additive `pumpGroup` field through SDK + CP — tracked separately.
       pumpOptions.pulse = {
         url: this.pulseConfig.url,
         intervalMs: this.pulseConfig.intervalMs,
-        pathwayId: `${baseId}::${flowType}::${pumpGroup}`,
+        pathwayId: this.pulseConfig.pathwayId,
         successLogLevel: this.pulseConfig.successLogLevel,
         failureLogLevel: this.pulseConfig.failureLogLevel,
       }

--- a/tests/pathway-pump.test.ts
+++ b/tests/pathway-pump.test.ts
@@ -232,37 +232,44 @@ Deno.test({
       )
     })
 
-    await t.step("pulse pathwayId is suffixed with ::flowType::pumpGroup", async () => {
-      const factory = createInMemoryStateFactory()
-      const pump = new PathwayPump({
-        stateManagerFactory: factory,
-        notifier: { type: "poller", pollerIntervalMs: 1000 },
-        pulse: { url: "http://cp.test", pathwayId: "p-123" },
-      })
+    await t.step(
+      "pulse pathwayId is forwarded unmodified (CP requires UUID, no ::flowType::pumpGroup suffix)",
+      async () => {
+        const factory = createInMemoryStateFactory()
+        const pump = new PathwayPump({
+          stateManagerFactory: factory,
+          notifier: { type: "poller", pollerIntervalMs: 1000 },
+          pulse: { url: "http://cp.test", pathwayId: "p-123" },
+        })
 
-      pump.configure({
-        tenant: "t",
-        dataCore: "dc",
-        apiKey: "k",
-        baseUrl: "https://api.flowcore.io",
-        processEvent: async () => {},
-      })
+        pump.configure({
+          tenant: "t",
+          dataCore: "dc",
+          apiKey: "k",
+          baseUrl: "https://api.flowcore.io",
+          processEvent: async () => {},
+        })
 
-      const seen: string[] = []
-      const internal = pump as unknown as InternalPump
-      internal.dataPumpConstructor = {
-        create: (options: Record<string, unknown>) => {
-          const pulse = options.pulse as { pathwayId: string }
-          seen.push(pulse.pathwayId)
-          return Promise.resolve({ start: async () => {} })
-        },
-      }
+        const seen: string[] = []
+        const internal = pump as unknown as InternalPump
+        internal.dataPumpConstructor = {
+          create: (options: Record<string, unknown>) => {
+            const pulse = options.pulse as { pathwayId: string }
+            seen.push(pulse.pathwayId)
+            return Promise.resolve({ start: async () => {} })
+          },
+        }
 
-      await internal.startPumpForGroup({ flowType: "orders", pumpGroup: "hot", eventTypes: ["placed.fast"] })
-      await internal.startPumpForGroup({ flowType: "orders", pumpGroup: "default", eventTypes: ["placed"] })
+        await internal.startPumpForGroup({ flowType: "orders", pumpGroup: "hot", eventTypes: ["placed.fast"] })
+        await internal.startPumpForGroup({ flowType: "orders", pumpGroup: "default", eventTypes: ["placed"] })
 
-      assertEquals(seen, ["p-123::orders::hot", "p-123::orders::default"])
-    })
+        // Same pathwayId on every group — the data-pathways CP pulse route validates
+        // pathwayId as a UUID and rejects anything else with 400 BAD_REQUEST. Per-group
+        // health visibility will return as a proper additive `pumpGroup` field through
+        // SDK + CP, not by mangling the pathwayId here.
+        assertEquals(seen, ["p-123", "p-123"])
+      },
+    )
 
     await t.step("notifier dataSource.eventTypes is restricted to the group's subset", async () => {
       const factory = createInMemoryStateFactory()
@@ -432,7 +439,7 @@ Deno.test({
       assertEquals(createdFlowTypes.sort(), ["order", "user"])
       assertEquals(
         createdPulsePathwayIds.sort(),
-        ["pathway-123::order::default", "pathway-123::user::default"],
+        ["pathway-123", "pathway-123"],
       )
       assertEquals(pump.isRunning, true)
       assertEquals(pump.registeredFlowTypes.sort(), ["order", "user"])


### PR DESCRIPTION
## Summary

2.4.0 (#80) introduced a per-group pulse identity at `PathwayPump.startPumpForGroup()`:

```ts
pathwayId: \`\${baseId}::\${flowType}::\${pumpGroup}\`,
```

The `data-pathways` CP pulse route (`POST /api/v1/pump-pulse`) validates `pathwayId: z.string().uuid()` strictly, so every 2.4.0 pulse — even from the implicit `default` group — gets `400 BAD_REQUEST: {"errors":{"pathwayId":"Invalid uuid"}}`. Confirmed in prod for `service-tenant-store-api` (every 30s, multiple pumps); confirmed CP source on origin/main has no awareness of the suffix and is still on `@flowcore/pathways@2.3.0`.

## Fix

Forward the resolved pathway UUID unmodified. Per-group health visibility (the stated 2.4.0 goal of distinguishing `hot` from `default` for the same flowType in the CP) will return as a **proper additive `pumpGroup` field** through SDK + CP routes — tracked as a follow-up. Not by mangling the pathwayId on the way out.

Diff:
```diff
 if (this.pulseConfig) {
-  const baseId = this.pulseConfig.pathwayId ?? "unknown"
   pumpOptions.pulse = {
     url: this.pulseConfig.url,
     intervalMs: this.pulseConfig.intervalMs,
-    pathwayId: \`\${baseId}::\${flowType}::\${pumpGroup}\`,
+    pathwayId: this.pulseConfig.pathwayId,
     successLogLevel: this.pulseConfig.successLogLevel,
     failureLogLevel: this.pulseConfig.failureLogLevel,
   }
 }
```

## Tests

- \`pathway-pump.test.ts\` "pulse pathwayId is forwarded unmodified" — renamed and updated to assert `["p-123", "p-123"]` instead of the suffixed form.
- \`pathway-pump.test.ts\` "setPulseConfig recreates running pumps with the new pulse configuration" — same UUID assertion.
- README §pumpGroup — replaced "Per-group pulse identity" bullet with a note explaining the CP UUID requirement and that per-group visibility will land additively.

## Test plan

- [x] \`deno fmt --check\` clean
- [x] \`deno lint\` clean
- [x] \`deno check src/mod.ts\` clean
- [x] \`deno test -A --ignore=tests/postgres-*.test.ts\` — **15 passed (139 steps)**

## Follow-up

Per-group pulse health (`pumpGroup` as a separate field) requires coordinated changes in `flowcore-sdk` (`SendPumpPulseInput`) and `data-pathways` CP (`pump-pulse` route schema + `pump_pulses` unique key). That can ship after this lands.