### PR TITLE
fix(pump): preserve factory arity 2 so per-pumpGroup state managers are honored

### DIFF
--- a/src/pathways/pump/state.ts
+++ b/src/pathways/pump/state.ts
@@ -112,7 +112,13 @@ export async function createPostgresPumpStateManagerFactory(
   const adapter = new PostgresJsAdapter(pgConfig)
   await adapter.connect()
 
-  return (flowType: string, pumpGroup: string = DEFAULT_PUMP_GROUP): PumpStateManager => {
-    return new PostgresPumpStateManager(adapter, flowType, pumpGroup, table)
+  // The returned function MUST declare `pumpGroup` without a default value so
+  // `Function.prototype.length === 2`. PathwayPump's arity check
+  // (`stateManagerFactoryArity <= 1`) treats single-arg factories as legacy and
+  // calls them with `flowType` only — collapsing every pumpGroup onto one
+  // shared state manager. The `?? DEFAULT_PUMP_GROUP` fallback inside the body
+  // preserves runtime safety for any external caller passing `undefined`.
+  return (flowType: string, pumpGroup: string): PumpStateManager => {
+    return new PostgresPumpStateManager(adapter, flowType, pumpGroup ?? DEFAULT_PUMP_GROUP, table)
   }
 }

--- a/tests/pathway-pump.test.ts
+++ b/tests/pathway-pump.test.ts
@@ -349,6 +349,71 @@ Deno.test({
       assertEquals([...pump.registeredFlowTypes].sort(), ["orders", "users"])
     })
 
+    await t.step(
+      "arity-2 state factory receives both (flowType, pumpGroup) so each group gets its own manager",
+      async () => {
+        // Regression: a factory declared with a default value on `pumpGroup`
+        // (e.g. `(flowType, pumpGroup = "default") => …`) has `.length === 1`,
+        // is detected as legacy, and is called with `flowType` only — collapsing
+        // every group onto a shared state manager. The factory MUST declare
+        // arity 2 (no defaults) so per-(flowType, pumpGroup) isolation works.
+        const calls: Array<{ flowType: string; pumpGroup: string | undefined }> = []
+        const stateByKey = new Map<string, InMemoryPumpStateManager>()
+        // Explicit arity 2 — `.length === 2`.
+        const factory = (flowType: string, pumpGroup: string): PumpStateManager => {
+          calls.push({ flowType, pumpGroup })
+          const key = `${flowType}::${pumpGroup}`
+          if (!stateByKey.has(key)) {
+            stateByKey.set(key, new InMemoryPumpStateManager())
+          }
+          return stateByKey.get(key)!
+        }
+
+        assertEquals(factory.length, 2, "factory must declare arity 2 — sanity check")
+
+        const warns: string[] = []
+        const pump = new PathwayPump({
+          stateManagerFactory: factory,
+          notifier: { type: "poller", pollerIntervalMs: 1000 },
+        }, {
+          debug: () => {},
+          info: () => {},
+          warn: (msg: string) => warns.push(msg),
+          error: () => {},
+        })
+
+        pump.configure({
+          tenant: "t",
+          dataCore: "dc",
+          apiKey: "k",
+          baseUrl: "https://api.flowcore.io",
+          processEvent: async () => {},
+        })
+
+        const internal = pump as unknown as InternalPump
+        internal.dataPumpConstructor = {
+          create: (_options: Record<string, unknown>) => Promise.resolve({ start: async () => {} }),
+        }
+
+        await internal.startPumpForGroup({ flowType: "orders", pumpGroup: "hot", eventTypes: ["placed.fast"] })
+        await internal.startPumpForGroup({ flowType: "orders", pumpGroup: "default", eventTypes: ["placed"] })
+
+        // Both args forwarded — legacy fallback was NOT taken.
+        assertEquals(calls, [
+          { flowType: "orders", pumpGroup: "hot" },
+          { flowType: "orders", pumpGroup: "default" },
+        ])
+        // Two distinct state manager instances exist, one per (flowType, pumpGroup).
+        assertEquals(stateByKey.size, 2)
+        // No legacy-arity warning.
+        assertEquals(
+          warns.filter((m) => m.includes("legacy single-arg signature")).length,
+          0,
+          "arity-2 factory must not trigger the legacy deprecation warning",
+        )
+      },
+    )
+
     await t.step("legacy single-arg state factory is accepted with a deprecation warning", async () => {
       const created = new Map<string, InMemoryPumpStateManager>()
       // Arity 1 — old factory signature.

--- a/tests/postgres-pump-state.test.ts
+++ b/tests/postgres-pump-state.test.ts
@@ -18,6 +18,31 @@ Deno.test({
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async (t) => {
+    await t.step(
+      "factory function declares arity 2 — PathwayPump treats arity<=1 as legacy and would call it with flowType only",
+      async () => {
+        const factory = await createPostgresPumpStateManagerFactory({ ...config, tableName: TABLE_NEW })
+        try {
+          // Function.prototype.length skips parameters with default values.
+          // PathwayPump (`stateManagerFactoryArity <= 1`) treats arity-1
+          // factories as legacy and collapses every pumpGroup onto a single
+          // shared state manager. The factory MUST declare both parameters
+          // without defaults to keep .length at 2 — runtime safety for
+          // `pumpGroup === undefined` is handled inside the factory body.
+          assertEquals(
+            factory.length,
+            2,
+            "createPostgresPumpStateManagerFactory must return a function with arity 2",
+          )
+        } finally {
+          const adapter = new PostgresJsAdapter(config)
+          await adapter.connect()
+          await adapter.execute(`DROP TABLE IF EXISTS ${TABLE_NEW}`)
+          await adapter.disconnect()
+        }
+      },
+    )
+
     await t.step("greenfield schema accepts composite (flow_type, pump_group)", async () => {
       const factory = await createPostgresPumpStateManagerFactory({ ...config, tableName: TABLE_NEW })
       const adapter = new PostgresJsAdapter(config)


### PR DESCRIPTION
## Summary

`createPostgresPumpStateManagerFactory` returned a function with a default value on `pumpGroup`:

```ts
return (flowType: string, pumpGroup: string = DEFAULT_PUMP_GROUP) => …
```

JavaScript's `Function.prototype.length` skips parameters with default values, so this function's `.length === 1`. `PathwayPump`'s arity check at `pathway-pump.ts:239`:

```ts
if (this.stateManagerFactoryArity <= 1) {
  // legacy fallback — call with flowType only
  return (this.stateManagerFactory as unknown as (flowType: string) => PumpStateManager)(flowType)
}
```

…treats the library's *own* factory as a "legacy" single-arg factory and invokes it with `flowType` only. The defaulted `pumpGroup` becomes `"default"` for every pump, so two pumps on the same flowType with different `pumpGroup` values share a single `PostgresPumpStateManager` keyed `(flowType, "default")`.

## Production evidence

Verified in `service-tenant-store-api@1.6.3` (which registers `tenant.0/api-key.used.0` with `pumpGroup: "hot"` and 12 other tenant.0 event types under the implicit `default` group):

- `_pathway_pump_state` contained **only one row** for `tenant.0` (the `default` group). The `(tenant.0, hot)` row was never inserted, even though the schema has `PRIMARY KEY (flow_type, pump_group)` and supports it.
- The `default` row's `event_id` was verifiably an `api-key.used.0` event id (the only event type with activity in that bucket). The default pump — whose `eventTypes` filter excludes `api-key.used.0` — was advancing past `api-key.used.0` events because its state manager was shared with the hot pump.
- The hot pump silently no-op'd: shared cursor advanced past its events, fetches returned empty batches, no acks, no `setState` calls, no row.

## Fix

Drop the default value on the second parameter so `.length === 2`. Move the runtime fallback inside the body:

```diff
-  return (flowType: string, pumpGroup: string = DEFAULT_PUMP_GROUP): PumpStateManager => {
-    return new PostgresPumpStateManager(adapter, flowType, pumpGroup, table)
+  return (flowType: string, pumpGroup: string): PumpStateManager => {
+    return new PostgresPumpStateManager(adapter, flowType, pumpGroup ?? DEFAULT_PUMP_GROUP, table)
   }
```

`PathwayPump` now takes the non-legacy branch and forwards both `(flowType, pumpGroup)` to the factory. Each pair gets its own state manager and its own row in `_pathway_pump_state`. The `?? DEFAULT_PUMP_GROUP` inside the body preserves runtime safety for any external caller passing `undefined` — same observable behaviour as before for legacy callers.

## Tests

- **`tests/postgres-pump-state.test.ts`** — new step `factory function declares arity 2 …`. Asserts `factory.length === 2`. This is the direct regression catch.
- **`tests/pathway-pump.test.ts`** — new step `arity-2 state factory receives both (flowType, pumpGroup) so each group gets its own manager`. Constructs a `PathwayPump` with an arity-2 mock factory, runs `startPumpForGroup` for `hot` and `default` groups, asserts the factory was called with `[("orders", "hot"), ("orders", "default")]`, two distinct managers were instantiated, and **no** legacy-arity warning was emitted.

The existing legacy test ("legacy single-arg state factory is accepted with a deprecation warning") still passes — backward compatibility for genuinely arity-1 user-provided factories is preserved.

## Test plan

- [x] `deno fmt --check` clean
- [x] `deno lint` clean
- [x] `deno check src/mod.ts` clean
- [x] `deno test -A --ignore=tests/postgres-*.test.ts` — **15 passed (140 steps)**
- [ ] Postgres tests after this lands — covered by the existing `test:postgres` task.

## Risk notes

- **Tiny blast radius.** One-line library change. The factory's runtime semantics for any well-formed caller are identical.
- **Existing user factories** with arity 1 continue to work unchanged via the legacy fallback path.
- **No data migration.** The composite-PK migration on `_pathway_pump_state` already shipped in 2.4.0. New `(flow_type, pump_group)` rows will be inserted on first hot-pump `setState` per consumer service after they bump.

## Related fragments

- [`f98a5d4b-…`](https://usable.dev/dashboard/workspaces/60c10ca2-4115-4c1a-b6d7-04ac39fd3938/fragments/f98a5d4b-192b-4e91-a945-ce5b427ae3a9) — original 2.4.0 `pumpGroup` release.
- [`c2ee688f-…`](https://usable.dev/dashboard/workspaces/60c10ca2-4115-4c1a-b6d7-04ac39fd3938/fragments/c2ee688f-d4bf-4466-a64c-4bca3c0058fb) — 2.4.1 pulse pathwayId fix.
- [`f7736088-…`](https://usable.dev/dashboard/workspaces/60c10ca2-4115-4c1a-b6d7-04ac39fd3938/fragments/f7736088-2462-4ed9-8b27-f7575146006b) — service-tenant-store-api 1.6.0 → 1.6.3 production rollout (same service that surfaced this bug).