### PR TITLE
fix(builder): provision() respects autoProvision + per-call override

### DIFF
--- a/bin/build-npm.ts
+++ b/bin/build-npm.ts
@@ -33,6 +33,9 @@ await build({
       "bun-sqlite-key-value": undefined as unknown as string,
       "ws": "^8.18.0",
       "zod": undefined as unknown as string,
+      // date-fns 4.2.0 dropped the top-level `types` field; TS 5.x (via dnt 0.41.3) can't
+      // resolve type defs through its exports map, so pin to the last known-good version.
+      "date-fns": "4.1.0",
     },
     devDependencies: {
       "@types/ws": "^8.5.10",

--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,7 @@
     "file-type": "npm:file-type@^21.0.0",
     "node-cache": "npm:node-cache@^5.1.2",
     "rxjs": "npm:rxjs@^7.8.1",
-    "@flowcore/data-pump": "jsr:@flowcore/data-pump@^0.19.0",
+    "@flowcore/data-pump": "jsr:@flowcore/data-pump@^0.21.2",
     "@flowcore/sdk": "npm:@flowcore/sdk@^1.78.0",
     "postgres": "npm:postgres@^3.4.3",
     "ws": "npm:ws@^8.18.0",

--- a/deno.lock
+++ b/deno.lock
@@ -5,45 +5,41 @@
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
-    "jsr:@flowcore/data-pump@0.19": "0.19.0",
-    "jsr:@flowcore/sdk@^1.78.0": "1.78.0",
+    "jsr:@flowcore/data-pump@~0.21.2": "0.21.2",
+    "jsr:@flowcore/sdk@^1.78.0": "1.79.0",
     "jsr:@flowcore/time-uuid@~0.1.1": "0.1.2",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/fmt@0.223": "0.223.0",
-    "jsr:@std/fmt@1": "1.0.3",
+    "jsr:@std/fmt@1": "1.0.9",
     "jsr:@std/fs@0.223": "0.223.0",
-    "jsr:@std/fs@1": "1.0.8",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@~0.229.3": "0.229.3",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/path@0.223": "0.223.0",
-    "jsr:@std/path@1": "1.0.8",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@1.0.0-rc.1": "1.0.0-rc.1",
-    "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/path@~0.225.2": "0.225.2",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "npm:@date-fns/utc@^2.1.0": "2.1.1",
-    "npm:@flowcore/sdk-oidc-client@*": "1.3.1",
-    "npm:@flowcore/sdk-transformer-core@^2.3.6": "2.5.1",
     "npm:@flowcore/sdk-transformer-core@^2.5.1": "2.5.1",
     "npm:@flowcore/sdk@^1.78.0": "1.79.0",
     "npm:@sinclair/typebox@0.32.15": "0.32.15",
-    "npm:@types/node@*": "22.15.5",
-    "npm:bun-sqlite-key-value@1.13.1": "1.13.1_typescript@5.8.2",
-    "npm:bun-sqlite-key-value@^1.13.1": "1.13.1_typescript@5.8.2",
-    "npm:date-fns@^4.1.0": "4.1.0",
-    "npm:file-type@21": "21.0.0",
+    "npm:bun-sqlite-key-value@^1.13.1": "1.13.1_typescript@5.9.3",
+    "npm:date-fns@^4.1.0": "4.2.0",
+    "npm:file-type@21": "21.3.4",
     "npm:long@^5.3.1": "5.3.2",
     "npm:nats@^2.29.1": "2.29.3",
-    "npm:node-cache@5.1.2": "5.1.2",
     "npm:node-cache@^5.1.2": "5.1.2",
-    "npm:postgres@^3.4.3": "3.4.5",
+    "npm:postgres@^3.4.3": "3.4.9",
     "npm:prom-client@^15.1.3": "15.1.3",
     "npm:rxjs@^7.8.1": "7.8.2",
-    "npm:ws@^8.18.0": "8.19.0",
-    "npm:zod@^3.25.63": "3.25.63"
+    "npm:ws@^8.18.0": "8.20.1",
+    "npm:zod@^3.25.63": "3.25.76"
   },
   "jsr": {
     "@david/code-block-writer@13.0.3": {
@@ -73,8 +69,8 @@
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
-    "@flowcore/data-pump@0.19.0": {
-      "integrity": "deca6643f61d97b25ec4b92e1f3039999893ce2b638ce4beec448d922c79a90b",
+    "@flowcore/data-pump@0.21.2": {
+      "integrity": "12e099be88e297fec075020d2e93765f48eee232b47374149a34dff8a0b2398f",
       "dependencies": [
         "jsr:@flowcore/sdk@^1.78.0",
         "jsr:@flowcore/time-uuid",
@@ -85,8 +81,8 @@
         "npm:rxjs"
       ]
     },
-    "@flowcore/sdk@1.78.0": {
-      "integrity": "1e1c5c7f2aa22f47a5093e324ba21547a451b1702a4a4d0f1bb5e5c8761ac0c9",
+    "@flowcore/sdk@1.79.0": {
+      "integrity": "267a42ce3a54946361946d7ccbde769c1bafe2b5874f71e67642f4a1f6d0c026",
       "dependencies": [
         "npm:@sinclair/typebox",
         "npm:rxjs"
@@ -110,8 +106,8 @@
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
     },
-    "@std/fmt@1.0.3": {
-      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
     },
     "@std/fs@0.223.0": {
       "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
@@ -122,11 +118,15 @@
         "jsr:@std/path@1.0.0-rc.1"
       ]
     },
-    "@std/fs@1.0.8": {
-      "integrity": "161c721b6f9400b8100a851b6f4061431c538b204bb76c501d02c508995cffe0",
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/path@^1.0.8"
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
       ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
     "@std/io@0.223.0": {
       "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
@@ -150,8 +150,11 @@
     "@std/path@1.0.0-rc.1": {
       "integrity": "b8c00ae2f19106a6bb7cbf1ab9be52aa70de1605daeb2dbdc4f87a7cbaf10ff6"
     },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
     },
     "@ts-morph/bootstrap@0.24.0": {
       "integrity": "a826a2ef7fa8a7c3f1042df2c034d20744d94da2ee32bf29275bcd4dffd3c060",
@@ -168,6 +171,9 @@
     }
   },
   "npm": {
+    "@borewit/text-codec@0.2.2": {
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="
+    },
     "@date-fns/utc@2.1.1": {
       "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA=="
     },
@@ -180,9 +186,6 @@
         "@deno/shim-deno-test",
         "which"
       ]
-    },
-    "@flowcore/sdk-oidc-client@1.3.1": {
-      "integrity": "sha512-fUHOmKDQYMqMDlh/KucJiDZ9he12QUkQ2KOJKCVy6GD7qsJs9qiJ8jV9th1Xeuz9kAca4TRXt+spMUhZ4CfUDw=="
     },
     "@flowcore/sdk-transformer-core@2.5.1": {
       "integrity": "sha512-RgXxMBsF/SxpE5libbPA+RKKM8tXJtKJKiHV86nY0ALY+5xSOmGXbvw1qUndwgOxSv5xiwL9rty0p1gLPFXmtw==",
@@ -206,27 +209,20 @@
     "@sinclair/typebox@0.32.15": {
       "integrity": "sha512-5Lrwo7VOiWEBJBhHmqNmf3TPB9ll8gcEshvYJyAIJyCZ2PF48MFOtiDHJNj8+FsNcqImaQYmxVkKBCBlyAa/wg=="
     },
-    "@tokenizer/inflate@0.2.7": {
-      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+    "@tokenizer/inflate@0.4.1": {
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
       "dependencies": [
         "debug",
-        "fflate",
         "token-types"
       ]
     },
     "@tokenizer/token@0.3.0": {
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
-    "@types/node@22.15.5": {
-      "integrity": "sha512-e3r3tiKxBr9e/+5uNRkF+K/2gnhR2V/EOY/gxNXviodSa3DYSqkYUR2Xp05l2uS/A7j864m8IQvdf+itWNIg1Q==",
-      "dependencies": [
-        "undici-types"
-      ]
-    },
     "bintrees@1.0.2": {
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
-    "bun-sqlite-key-value@1.13.1_typescript@5.8.2": {
+    "bun-sqlite-key-value@1.13.1_typescript@5.9.3": {
       "integrity": "sha512-cb3thB8QXPeXB6B7NhObpADEYvtVNwqg/0ED7PgKt2OxVAxPSejkiTsy1+byQDC0AwLYajw3nhtr/ubKvcLcKw==",
       "dependencies": [
         "typescript"
@@ -235,20 +231,17 @@
     "clone@2.1.2": {
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
-    "date-fns@4.1.0": {
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+    "date-fns@4.2.0": {
+      "integrity": "sha512-Xztieol+KNB9MxhgS6v44YZt0xa8DN7CtKQCvHLwVE8/AaKv2eYiAACaJ9bHgCbOhfSigA3D7FRgXRLa/eZVpA=="
     },
-    "debug@4.4.0": {
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
         "ms"
       ]
     },
-    "fflate@0.8.2": {
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
-    },
-    "file-type@21.0.0": {
-      "integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+    "file-type@21.3.4": {
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "dependencies": [
         "@tokenizer/inflate",
         "strtok3",
@@ -272,7 +265,8 @@
       "integrity": "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==",
       "dependencies": [
         "nkeys.js"
-      ]
+      ],
+      "deprecated": true
     },
     "nkeys.js@1.1.0": {
       "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
@@ -286,11 +280,8 @@
         "clone"
       ]
     },
-    "peek-readable@7.0.0": {
-      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ=="
-    },
-    "postgres@3.4.5": {
-      "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg=="
+    "postgres@3.4.9": {
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="
     },
     "prom-client@15.1.3": {
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
@@ -308,11 +299,10 @@
         "tslib"
       ]
     },
-    "strtok3@10.2.2": {
-      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+    "strtok3@10.3.5": {
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "dependencies": [
-        "@tokenizer/token",
-        "peek-readable"
+        "@tokenizer/token"
       ]
     },
     "tdigest@0.1.2": {
@@ -321,9 +311,10 @@
         "bintrees"
       ]
     },
-    "token-types@6.0.0": {
-      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+    "token-types@6.1.2": {
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "dependencies": [
+        "@borewit/text-codec",
         "@tokenizer/token",
         "ieee754"
       ]
@@ -334,15 +325,12 @@
     "tweetnacl@1.0.3": {
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
-    "typescript@5.8.2": {
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+    "typescript@5.9.3": {
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "bin": true
     },
-    "uint8array-extras@1.4.0": {
-      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ=="
-    },
-    "undici-types@6.21.0": {
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    "uint8array-extras@1.5.0": {
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
     },
     "which@4.0.0": {
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
@@ -351,68 +339,17 @@
       ],
       "bin": true
     },
-    "ws@8.19.0": {
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
+    "ws@8.20.1": {
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="
     },
-    "zod@3.25.63": {
-      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw=="
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
-  },
-  "redirects": {
-    "https://deno.land/std/assert/mod.ts": "https://deno.land/std@0.224.0/assert/mod.ts",
-    "https://deno.land/std/testing/bdd.ts": "https://deno.land/std@0.224.0/testing/bdd.ts"
-  },
-  "remote": {
-    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
-    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
-    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
-    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
-    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
-    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
-    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
-    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
-    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
-    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
-    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
-    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
-    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
-    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
-    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
-    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
-    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
-    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
-    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
-    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
-    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
-    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
-    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
-    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
-    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
-    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
-    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
-    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
-    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
-    "https://deno.land/std@0.224.0/async/delay.ts": "f90dd685b97c2f142b8069082993e437b1602b8e2561134827eeb7c12b95c499",
-    "https://deno.land/std@0.224.0/data_structures/_binary_search_node.ts": "ce1da11601fef0638df4d1e53c377f791f96913383277389286b390685d76c07",
-    "https://deno.land/std@0.224.0/data_structures/_red_black_node.ts": "4af8d3c5ac5f119d8058269259c46ea22ead567246cacde04584a83e43a9d2ea",
-    "https://deno.land/std@0.224.0/data_structures/binary_search_tree.ts": "2dd43d97ce5f5a4bdba11b075eb458db33e9143f50997b0eebf02912cb44f5d5",
-    "https://deno.land/std@0.224.0/data_structures/comparators.ts": "17dfa68bf1550edadbfdd453a06f9819290bcb534c9945b5cec4b30242cff475",
-    "https://deno.land/std@0.224.0/data_structures/red_black_tree.ts": "2222be0c46842fc932e2c8589a66dced9e6eae180914807c5c55d1aa4c8c1b9b",
-    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
-    "https://deno.land/std@0.224.0/http/server.ts": "f9313804bf6467a1704f45f76cb6cd0a3396a3b31c316035e6a4c2035d1ea514",
-    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
-    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
-    "https://deno.land/std@0.224.0/testing/_test_suite.ts": "f10a8a6338b60c403f07a76f3f46bdc9f1e1a820c0a1decddeb2949f7a8a0546",
-    "https://deno.land/std@0.224.0/testing/_time.ts": "fefd1ff35b50a410db9b0e7227e05163e1b172c88afd0d2071df0125958c3ff3",
-    "https://deno.land/std@0.224.0/testing/bdd.ts": "3e4de4ff6d8f348b5574661cef9501b442046a59079e201b849d0e74120d476b",
-    "https://deno.land/std@0.224.0/testing/mock.ts": "a963181c2860b6ba3eb60e08b62c164d33cf5da7cd445893499b2efda20074db",
-    "https://deno.land/std@0.224.0/testing/time.ts": "7119072a198e9913da0d21106b1f05a90a4c05b07075529770ff0e2a9eb5eaba"
   },
   "workspace": {
     "dependencies": [
       "jsr:@deno/dnt@~0.41.3",
-      "jsr:@flowcore/data-pump@0.19",
+      "jsr:@flowcore/data-pump@~0.21.2",
       "npm:@flowcore/sdk-transformer-core@^2.5.1",
       "npm:@flowcore/sdk@^1.78.0",
       "npm:bun-sqlite-key-value@^1.13.1",

--- a/src/pathways/builder.ts
+++ b/src/pathways/builder.ts
@@ -1778,14 +1778,31 @@ export class PathwaysBuilder<
   }
 
   /**
-   * Provision Flowcore infrastructure (data core, flow types, event types).
-   * Creates missing resources when descriptions are provided, updates descriptions
-   * when they differ. Fails if a resource is missing and no description is provided.
+   * Provision Flowcore infrastructure honoring `autoProvision`.
+   *
+   * By default this only provisions shared resources (data core, flow types, event types)
+   * because `DEFAULT_AUTO_PROVISION.pathway` is `false`. To also upsert the pathway
+   * instance (managed or virtual by-name), opt in via builder-level
+   * `autoProvision: { pathway: true }` or pass an override here.
+   *
    * Additive only — never deletes.
    */
-  async provision(): Promise<void> {
-    const registrations = await this.provisionSharedResources()
-    await this.registerPathwayInstance(registrations)
+  async provision(autoProvisionOverride?: boolean | AutoProvisionConfig): Promise<void> {
+    const ap = autoProvisionOverride != null ? resolveAutoProvision(autoProvisionOverride) : this.autoProvision
+
+    const shouldProvisionResources = ap.dataCore || ap.flowType || ap.eventType
+    let registrations: ProvisionerRegistration[] | null = null
+    if (shouldProvisionResources) {
+      registrations = await this.provisionSharedResources({
+        skipDataCore: !ap.dataCore,
+        skipFlowTypes: !ap.flowType,
+        skipEventTypes: !ap.eventType,
+      })
+    }
+
+    if (ap.pathway) {
+      await this.registerPathwayInstance(registrations ?? this.buildRegistrations())
+    }
   }
 
   /**

--- a/tests/pathway-builder-provision.test.ts
+++ b/tests/pathway-builder-provision.test.ts
@@ -1,0 +1,193 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts"
+import { stub } from "https://deno.land/std@0.224.0/testing/mock.ts"
+import { z } from "zod"
+import { PathwaysBuilder, type PathwaysBuilderConfig } from "../src/pathways/builder.ts"
+import { PathwayProvisioner } from "../src/pathways/provisioner.ts"
+
+const baseOpts = {
+  baseUrl: "https://api.flowcore.io",
+  tenant: "test-tenant",
+  dataCore: "test-dc",
+  apiKey: "fc_testid_testsecret",
+  dataCoreDescription: "Test data core",
+}
+
+function createBuilder(overrides: Partial<PathwaysBuilderConfig> = {}) {
+  return new PathwaysBuilder({
+    ...baseOpts,
+    ...overrides,
+  }).register({
+    flowType: "user.0",
+    eventType: "created.0",
+    schema: z.object({ id: z.string() }),
+    flowTypeDescription: "User events",
+    description: "User created",
+  })
+}
+
+Deno.test({
+  name: "PathwaysBuilder.provision honors autoProvision",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async (t) => {
+    await t.step(
+      "managed prod default — provisions shared resources, skips pathway upsert (no endpointUrl needed)",
+      async () => {
+        let provisionCalls = 0
+        let fetchCalls = 0
+        const provisionStub = stub(PathwayProvisioner.prototype, "provision", async () => {
+          provisionCalls++
+        })
+        const fetchStub = stub(globalThis, "fetch", async () => {
+          fetchCalls++
+          return new Response("{}", { status: 200 })
+        })
+
+        try {
+          const builder = createBuilder({
+            runtimeEnv: "production",
+            // pathwayMode defaults to "managed" in production; intentionally NO managedConfig
+          })
+
+          await builder.provision()
+
+          assertEquals(provisionCalls, 1, "shared resources should be provisioned once")
+          assertEquals(fetchCalls, 0, "no pathway upsert HTTP call when pathway autoProvision is off")
+        } finally {
+          provisionStub.restore()
+          fetchStub.restore()
+        }
+      },
+    )
+
+    await t.step(
+      "autoProvision.pathway=true upserts the managed pathway (requires managedConfig)",
+      async () => {
+        let provisionCalls = 0
+        const fetchBodies: Array<Record<string, unknown>> = []
+        const provisionStub = stub(PathwayProvisioner.prototype, "provision", async () => {
+          provisionCalls++
+        })
+        const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
+          fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+          return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        })
+
+        try {
+          const builder = createBuilder({
+            runtimeEnv: "production",
+            pathwayName: "managed-service",
+            autoProvision: { pathway: true },
+            managedConfig: {
+              endpointUrl: "https://example.com/api/transformer",
+              authHeaders: { "x-test": "1" },
+            },
+          })
+
+          await builder.provision()
+
+          assertEquals(provisionCalls, 1)
+          assertEquals(fetchBodies.length, 1)
+          assertEquals(fetchBodies[0].type, "managed")
+        } finally {
+          provisionStub.restore()
+          fetchStub.restore()
+        }
+      },
+    )
+
+    await t.step(
+      "virtual pathway default — provisions shared resources, skips by-name pathway upsert",
+      async () => {
+        let provisionCalls = 0
+        let fetchCalls = 0
+        const provisionStub = stub(PathwayProvisioner.prototype, "provision", async () => {
+          provisionCalls++
+        })
+        const fetchStub = stub(globalThis, "fetch", async () => {
+          fetchCalls++
+          return new Response("{}", { status: 200 })
+        })
+
+        try {
+          const builder = createBuilder({
+            runtimeEnv: "production",
+            pathwayMode: "virtual",
+            pathwayName: "virtual-service",
+          })
+
+          await builder.provision()
+
+          assertEquals(provisionCalls, 1)
+          assertEquals(fetchCalls, 0, "by-name virtual upsert should be skipped when pathway autoProvision is off")
+        } finally {
+          provisionStub.restore()
+          fetchStub.restore()
+        }
+      },
+    )
+
+    await t.step("autoProvision=false skips everything", async () => {
+      let provisionCalls = 0
+      let fetchCalls = 0
+      const provisionStub = stub(PathwayProvisioner.prototype, "provision", async () => {
+        provisionCalls++
+      })
+      const fetchStub = stub(globalThis, "fetch", async () => {
+        fetchCalls++
+        return new Response("{}", { status: 200 })
+      })
+
+      try {
+        const builder = createBuilder({
+          runtimeEnv: "production",
+          defaultAutoProvision: false,
+        })
+
+        await builder.provision()
+
+        assertEquals(provisionCalls, 0)
+        assertEquals(fetchCalls, 0)
+      } finally {
+        provisionStub.restore()
+        fetchStub.restore()
+      }
+    })
+
+    await t.step("per-call override wins over builder-level autoProvision", async () => {
+      let provisionCalls = 0
+      const fetchBodies: Array<Record<string, unknown>> = []
+      const provisionStub = stub(PathwayProvisioner.prototype, "provision", async () => {
+        provisionCalls++
+      })
+      const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
+        fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+        return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      })
+
+      try {
+        // Builder says pathway: false (default), per-call override flips it on.
+        const builder = createBuilder({
+          runtimeEnv: "production",
+          pathwayName: "managed-service",
+          managedConfig: { endpointUrl: "https://example.com/api/transformer" },
+        })
+
+        await builder.provision({ pathway: true })
+
+        assertEquals(provisionCalls, 1)
+        assertEquals(fetchBodies.length, 1)
+        assertEquals(fetchBodies[0].type, "managed")
+      } finally {
+        provisionStub.restore()
+        fetchStub.restore()
+      }
+    })
+  },
+})

--- a/tests/pathway-builder-provision.test.ts
+++ b/tests/pathway-builder-provision.test.ts
@@ -69,7 +69,7 @@ Deno.test({
           provisionCalls++
         })
         const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
-          fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+          fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
           return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -164,7 +164,7 @@ Deno.test({
         provisionCalls++
       })
       const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
-        fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+        fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
         return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },

--- a/tests/pump-runtime-behavior.test.ts
+++ b/tests/pump-runtime-behavior.test.ts
@@ -172,7 +172,7 @@ Deno.test({
         })
         const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
           lifecycle.push("fetch")
-          fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+          fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
           return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -251,7 +251,7 @@ Deno.test({
         })
         const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
           lifecycle.push("fetch")
-          fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+          fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
           return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -442,7 +442,7 @@ Deno.test({
         startCalls++
       })
       const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
-        fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+        fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
         return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -490,7 +490,7 @@ Deno.test({
           startCalls++
         })
         const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
-          fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+          fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
           return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
             status: 200,
             headers: { "Content-Type": "application/json" },
@@ -570,7 +570,7 @@ Deno.test({
         startCalls++
       })
       const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
-        fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+        fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
         return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -609,7 +609,7 @@ Deno.test({
         startCalls++
       })
       const fetchStub = stub(globalThis, "fetch", async (_input, init) => {
-        fetchBodies.push(JSON.parse(String(init?.body ?? "{}")))
+        fetchBodies.push(JSON.parse(String((init as RequestInit | undefined)?.body ?? "{}")))
         return new Response(JSON.stringify({ pathwayId: crypto.randomUUID(), status: "created" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- `PathwaysBuilder.provision()` previously ignored `autoProvision` and always called `registerPathwayInstance()`, which crashed in prod (`pathwayMode: "managed"` default) when no `managedConfig.endpointUrl` was supplied — even with `autoProvision.pathway: false`.
- `provision()` now mirrors `startPump()` semantics: shared-resource provisioning is gated on `dataCore` / `flowType` / `eventType`, and the pathway instance is upserted only when `pathway: true`.
- Adds an optional per-call override argument so callers can flip the behavior at a specific call-site (parity with `startPump(options.autoProvision)`).

### Why this matters
`usable-chat` production boot is currently crash-looping because the bootstrap calls `pathways.provision()` and the library tries to upsert a managed pathway despite `autoProvision: { pathway: false }`. The managed pathway is managed manually via CP/MCP — the library should never auto-create it. This patch unblocks that deployment.

## Test plan
- [x] New test suite `tests/pathway-builder-provision.test.ts` (5 steps), all passing:
  - managed prod default → shared resources only, no pathway upsert (no `endpointUrl` needed)
  - `autoProvision: { pathway: true }` → managed upsert fires
  - virtual default → shared resources only, no by-name upsert
  - `defaultAutoProvision: false` → nothing provisioned
  - per-call override beats builder-level setting
- [x] Existing builder/pump/router suites: 16 passed (145 steps) when postgres-backed tests are excluded (require local postgres)
- [ ] CI green