### PR TITLE
fix: demote lifecycle logs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -27,8 +27,8 @@
     "file-type": "npm:file-type@^21.0.0",
     "node-cache": "npm:node-cache@^5.1.2",
     "rxjs": "npm:rxjs@^7.8.1",
-    "@flowcore/data-pump": "jsr:@flowcore/data-pump@^0.21.2",
-    "@flowcore/sdk": "npm:@flowcore/sdk@^1.78.0",
+    "@flowcore/data-pump": "jsr:@flowcore/data-pump@^0.21.3",
+    "@flowcore/sdk": "npm:@flowcore/sdk@^4.2.2",
     "postgres": "npm:postgres@^3.4.3",
     "ws": "npm:ws@^8.18.0",
     "zod": "npm:zod@^3.25.63"

--- a/deno.lock
+++ b/deno.lock
@@ -5,8 +5,8 @@
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
-    "jsr:@flowcore/data-pump@~0.21.2": "0.21.2",
-    "jsr:@flowcore/sdk@^1.78.0": "1.79.0",
+    "jsr:@flowcore/data-pump@~0.21.3": "0.21.3",
+    "jsr:@flowcore/sdk@^4.2.2": "4.2.2",
     "jsr:@flowcore/time-uuid@~0.1.1": "0.1.2",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
@@ -27,10 +27,10 @@
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "npm:@date-fns/utc@^2.1.0": "2.1.1",
     "npm:@flowcore/sdk-transformer-core@^2.5.1": "2.5.1",
-    "npm:@flowcore/sdk@^1.78.0": "1.79.0",
+    "npm:@flowcore/sdk@^4.2.2": "4.2.2",
     "npm:@sinclair/typebox@0.32.15": "0.32.15",
     "npm:bun-sqlite-key-value@^1.13.1": "1.13.1_typescript@5.9.3",
-    "npm:date-fns@^4.1.0": "4.2.0",
+    "npm:date-fns@^4.1.0": "4.4.0",
     "npm:file-type@21": "21.3.4",
     "npm:long@^5.3.1": "5.3.2",
     "npm:nats@^2.29.1": "2.29.3",
@@ -69,10 +69,10 @@
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
-    "@flowcore/data-pump@0.21.2": {
-      "integrity": "12e099be88e297fec075020d2e93765f48eee232b47374149a34dff8a0b2398f",
+    "@flowcore/data-pump@0.21.3": {
+      "integrity": "c18caf7623501b7d3b6d0eb85a577909481950ddf850958208aa7d701d49b0c0",
       "dependencies": [
-        "jsr:@flowcore/sdk@^1.78.0",
+        "jsr:@flowcore/sdk@^4.2.2",
         "jsr:@flowcore/time-uuid",
         "npm:@date-fns/utc",
         "npm:date-fns",
@@ -81,8 +81,8 @@
         "npm:rxjs"
       ]
     },
-    "@flowcore/sdk@1.79.0": {
-      "integrity": "267a42ce3a54946361946d7ccbde769c1bafe2b5874f71e67642f4a1f6d0c026",
+    "@flowcore/sdk@4.2.2": {
+      "integrity": "1f62166e11376d6e7aafa572e072665ea2e7591497254abce4e8b13b7b5d166c",
       "dependencies": [
         "npm:@sinclair/typebox",
         "npm:rxjs"
@@ -194,8 +194,8 @@
         "radash"
       ]
     },
-    "@flowcore/sdk@1.79.0": {
-      "integrity": "sha512-urO+30TGQPxRvQTxHig2kajwVm5M3L2BH1ibqtDi6PvNzwqxSzJht2qNuIVh4mEyltZPIF5n8PnBLeAQysmUTQ==",
+    "@flowcore/sdk@4.2.2": {
+      "integrity": "sha512-PRLXCAqzKfeacBRCAZJTPciycmqB4WJSGxS94mzkkVWhvP0AwDRj8/yA2pP2juygDZRvtHEkD57E9HBTVJ0ZBA==",
       "dependencies": [
         "@deno/shim-deno",
         "@sinclair/typebox",
@@ -231,8 +231,8 @@
     "clone@2.1.2": {
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
-    "date-fns@4.2.0": {
-      "integrity": "sha512-Xztieol+KNB9MxhgS6v44YZt0xa8DN7CtKQCvHLwVE8/AaKv2eYiAACaJ9bHgCbOhfSigA3D7FRgXRLa/eZVpA=="
+    "date-fns@4.4.0": {
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="
     },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -346,12 +346,47 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
+  "remote": {
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
+  },
   "workspace": {
     "dependencies": [
       "jsr:@deno/dnt@~0.41.3",
-      "jsr:@flowcore/data-pump@~0.21.2",
+      "jsr:@flowcore/data-pump@~0.21.3",
       "npm:@flowcore/sdk-transformer-core@^2.5.1",
-      "npm:@flowcore/sdk@^1.78.0",
+      "npm:@flowcore/sdk@^4.2.2",
       "npm:bun-sqlite-key-value@^1.13.1",
       "npm:file-type@21",
       "npm:node-cache@^5.1.2",

--- a/src/pathways/cluster/cluster-manager.ts
+++ b/src/pathways/cluster/cluster-manager.ts
@@ -528,7 +528,7 @@ export class ClusterManager {
       const ws = this.transport.connect(address)
 
       ws.onopen = () => {
-        this.logger.info("Connected to worker", { address })
+        this.logger.debug("Connected to worker", { address })
         this.workerConnections.set(address, ws)
       }
 
@@ -545,7 +545,7 @@ export class ClusterManager {
       }
 
       ws.onclose = () => {
-        this.logger.info("Disconnected from worker", { address })
+        this.logger.debug("Disconnected from worker", { address })
         this.workerConnections.delete(address)
         this.workerAddresses = this.workerAddresses.filter((a) => a !== address)
       }

--- a/tests/cluster-manager.test.ts
+++ b/tests/cluster-manager.test.ts
@@ -1,7 +1,9 @@
 import { assertEquals, assertExists } from "https://deno.land/std@0.224.0/assert/mod.ts"
 import type { PathwayCoordinator } from "../src/pathways/cluster/types.ts"
+import type { ClusterSocket, ClusterTransport } from "../src/pathways/cluster/types.ts"
 import { ClusterManager } from "../src/pathways/cluster/cluster-manager.ts"
 import type { FlowcoreEvent } from "../src/contracts/event.ts"
+import type { Logger, LoggerMeta } from "../src/pathways/logger.ts"
 
 /**
  * In-memory coordinator for testing
@@ -72,6 +74,36 @@ function createTestEvent(overrides?: Partial<FlowcoreEvent>): FlowcoreEvent {
     payload: { name: "test" },
     validTime: new Date().toISOString(),
     ...overrides,
+  }
+}
+
+function createRecordingLogger(): Logger & {
+  calls: { debug: string[]; info: string[]; warn: string[]; error: string[] }
+} {
+  const calls = {
+    debug: [] as string[],
+    info: [] as string[],
+    warn: [] as string[],
+    error: [] as string[],
+  }
+  return {
+    calls,
+    debug: (message: string, _context?: LoggerMeta) => calls.debug.push(message),
+    info: (message: string, _context?: LoggerMeta) => calls.info.push(message),
+    warn: (message: string, _context?: LoggerMeta) => calls.warn.push(message),
+    error: (messageOrError: string | Error) => calls.error.push(String(messageOrError)),
+  }
+}
+
+function createFakeClusterSocket(): ClusterSocket {
+  return {
+    readyState: 1,
+    send: () => {},
+    close: () => {},
+    onopen: null,
+    onmessage: null,
+    onclose: null,
+    onerror: null,
   }
 }
 
@@ -240,6 +272,32 @@ Deno.test({
       const instances2 = await coordinator.getInstances(60000)
       assertEquals(instances2.length, 1)
       assertEquals(instances2[0].instanceId, "inst-2")
+    })
+
+    await t.step("worker connection lifecycle logs should use debug, not info", () => {
+      const logger = createRecordingLogger()
+      const socket = createFakeClusterSocket()
+      const transport: ClusterTransport = {
+        startServer: () => Promise.resolve({ shutdown: () => Promise.resolve() }),
+        connect: () => socket,
+      }
+      const manager = new ClusterManager(
+        {
+          coordinator: new InMemoryCoordinator(),
+          advertisedAddress: "ws://localhost:19007",
+          port: 19007,
+          transport,
+        },
+        logger,
+      )
+      ;(manager as unknown as { connectToWorker(address: string): void }).connectToWorker("ws://worker:19008")
+      socket.onopen?.({})
+      socket.onclose?.({})
+
+      assertEquals(logger.calls.debug.includes("Connected to worker"), true)
+      assertEquals(logger.calls.debug.includes("Disconnected from worker"), true)
+      assertEquals(logger.calls.info.includes("Connected to worker"), false)
+      assertEquals(logger.calls.info.includes("Disconnected from worker"), false)
     })
   },
 })


### PR DESCRIPTION
## Summary
- demote worker connection lifecycle logs to debug
- bump @flowcore/data-pump to 0.21.3
- bump @flowcore/sdk to 4.2.2

## Tests
- deno fmt --check deno.json src/pathways/cluster/cluster-manager.ts tests/cluster-manager.test.ts
- deno test -A tests/cluster-manager.test.ts